### PR TITLE
fix(ci): provide GH_TOKEN for update-swagger workflow

### DIFF
--- a/.github/workflows/update-swagger.yml
+++ b/.github/workflows/update-swagger.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get Latest Swagger UI Release
         id: swagger-ui
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           release_tag=$(gh release view --repo swagger-api/swagger-ui --json tagName --jq '.tagName')
           echo "release_tag=$release_tag" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The updateSwagger workflow uses the GitHub CLI (gh) to query the latest swagger-ui release.\n\nThis PR sets GH_TOKEN for that step using the built-in `github.token` so `gh release view` can authenticate in GitHub Actions.